### PR TITLE
Fixed Copyright message in Registers

### DIFF
--- a/adafruit_ra8875/registers.py
+++ b/adafruit_ra8875/registers.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2017 Radomir Dopieralski and Adafruit Industries
+# Copyright (c) 2019 Melissa LeBlanc-Williams for Adafruit Industries
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed the year and author were wrong in registers (probably just a copy/paste error) and corrected them. No functional changes.